### PR TITLE
Add some adornments in the "default" namespace

### DIFF
--- a/ns-default/default-commits-to-cert.yaml
+++ b/ns-default/default-commits-to-cert.yaml
@@ -1,0 +1,15 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  labels:
+    app.kubernetes.io/part-of: commits-to
+  name: default-commits-to-cert
+  namespace: default
+spec:
+  dnsNames:
+  - '*.kingdonb.dev'
+  - 'kingdonb.dev'
+  issuerRef:
+    kind: Issuer
+    name: default-commits-to-issuer
+  secretName: default-commits-to-cert-secret

--- a/ns-default/default-commits-to-ingress.yaml
+++ b/ns-default/default-commits-to-ingress.yaml
@@ -1,0 +1,37 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    kubernetes.io/tls-acme: "true"
+  name: star-default-commits-to
+  namespace: default
+spec:
+  rules:
+  - host: kingdonb.dev
+    http:
+      paths:
+      - backend:
+          serviceName: commits-to
+          servicePort: 5000
+        path: /
+  - host: kpb.kingdonb.dev
+    http:
+      paths:
+      - backend:
+          serviceName: commits-to
+          servicePort: 5000
+        path: /
+  - host: klb.kingdonb.dev
+    http:
+      paths:
+      - backend:
+          serviceName: commits-to
+          servicePort: 5000
+        path: /
+  tls:
+  - hosts:
+    - kpb.kingdonb.dev
+    - klb.kingdonb.dev
+    - kingdonb.dev
+    secretName: default-commits-to-cert-secret

--- a/ns-default/default-commits-to-issuer.yaml
+++ b/ns-default/default-commits-to-issuer.yaml
@@ -1,0 +1,19 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: Issuer
+metadata:
+  labels:
+    app.kubernetes.io/part-of: commits-to
+  name: default-commits-to-issuer
+  namespace: default
+spec:
+  acme:
+    email: kingdon.b@nd.edu
+    privateKeySecretRef:
+      name: default-commits-to-letsencrypt
+    server: https://acme-v02.api.letsencrypt.org/directory
+    solvers:
+    - dns01:
+        digitalocean:
+          tokenSecretRef:
+            key: key
+            name: okteto-dns

--- a/ns-default/okteto-dns-sealed-secret.yaml
+++ b/ns-default/okteto-dns-sealed-secret.yaml
@@ -1,0 +1,16 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  creationTimestamp: null
+  name: okteto-dns
+  namespace: default
+spec:
+  encryptedData:
+    key: AgBvoIQeWdr1Udzk2TTPzKSnu9MBoOy5Ufte6EcK68JM8W+OYxSICSeSShI2VNcdRCHMJQUr0RyGcxZ5zt2AFZuESSj5ZLCj7Dl06/SyXBPZLvTKjwDGlsxTNf/q/TYMHYXOLP3M16TsHgmoRFTZT39/bCriL8MU6ePXjEg0Zwpwn00ACHY89FukBjGKqiJwKVCGsL+7giKTCu8c5ycW0KYJhbnM3hlENeU8OvoYyKRGmgaL/XSkJfUGwaGEEVcfuU5RYXlveHqWr6cshSbe2i97rE8sAe9/fhjOWXsEKj8pdcLQY52FHE8DRAnPpwlJnhl/xIOOasIPz41wAkgZyPArJa9QQWR+S9i5YMoYBtOex1FzvqKBH5g6aPpeFkFozAg0lko1/TxuCGTXP13FpRfWMZIPWoMd5S+R1NNNdDmAvvSRZQPj3xeKyxMenLCfCj6gkuJboKugP2xEj2e8GilcUY/gawAu5R+gbR2foPmEaACxb3iA8zJvq31TViqpcF/owUoTl7qjg1A7xG8RsJm6w4YD10TcVnj3RNdOqWjq0ExQv2hel168YE5aAjFWF/PC8ma+2K+8VtDWG5CJS3Yz31Jeujx1AXCfh9so05oFr5Op7sntI2N88UJZYyEs90xMgO/MCfBQAQwTZF3Zs1XDJoPOv5OI16Si/lwx4wChSlfnEzqp/FxWnu+h0Ny/Px3DVdgHXop4GPSOH1ZwxqaL73NOcOPTuSpPGVGu+QwB59aR8j+YP4WBmfbpLl/UdCnD+LmnFwua9GpjHoPB98yF
+  template:
+    metadata:
+      creationTimestamp: null
+      name: okteto-dns
+      namespace: default
+    type: Opaque
+


### PR DESCRIPTION
The DNS secret is the same as okteto-dns-secret from the okteto ns. The
cert + issuer will generate a TLS secret that is managed by cert-manager
for the kingdonb.dev and *.kingdonb.dev subject names, automatically!

Because of the way DNS is set up, these CNAMEs must be added manually.
Because of the way Commits-To works, the user rows must also be inserted
into the (Heroku-hosted, TLS-secured) Pg database manually, by an admin.

(Voila, production!)